### PR TITLE
モデルの翻訳情報追加

### DIFF
--- a/taskmanager_app/app/views/tasks/new.html.haml
+++ b/taskmanager_app/app/views/tasks/new.html.haml
@@ -1,7 +1,7 @@
 %h1 Tasks#new
 
 .nav.justify-content-end
-  = link_to(I18n.t('activerecord.terms.list'), tasks_path, class: 'nav=link')
+  = link_to(t('activerecord.terms.list'), tasks_path, class: 'nav=link')
 
 = form_with model: @task, local: true do |f|
   .form-group

--- a/taskmanager_app/app/views/tasks/new.html.haml
+++ b/taskmanager_app/app/views/tasks/new.html.haml
@@ -1,7 +1,7 @@
 %h1 Tasks#new
 
 .nav.justify-content-end
-  = link_to '一覧', tasks_path, class: 'nav=link'
+  = link_to(I18n.t('activerecord.terms.list'), tasks_path, class: 'nav=link')
 
 = form_with model: @task, local: true do |f|
   .form-group

--- a/taskmanager_app/app/views/tasks/new.html.haml
+++ b/taskmanager_app/app/views/tasks/new.html.haml
@@ -1,7 +1,7 @@
 %h1 Tasks#new
 
 .nav.justify-content-end
-  = link_to(t('activerecord.terms.list'), tasks_path, class: 'nav=link')
+  = link_to(t('helpers.list'), tasks_path, class: 'nav=link')
 
 = form_with model: @task, local: true do |f|
   .form-group

--- a/taskmanager_app/app/views/tasks/show.html.haml
+++ b/taskmanager_app/app/views/tasks/show.html.haml
@@ -1,7 +1,7 @@
 %h1 Tasks#show
 
 .nav.justify-content-end
-  = link_to(I18n.t('activerecord.terms.list'), tasks_path, class: 'nav-link')
+  = link_to(t('activerecord.terms.list'), tasks_path, class: 'nav-link')
 
 %table.table.table-hover
   %tbody

--- a/taskmanager_app/app/views/tasks/show.html.haml
+++ b/taskmanager_app/app/views/tasks/show.html.haml
@@ -1,7 +1,8 @@
 %h1 Tasks#show
 
 .nav.justify-content-end
-  = link_to('一覧', tasks_path, class: 'nav-link')
+  = link_to(I18n.t('activerecord.terms.list'), tasks_path, class: 'nav-link')
+
 %table.table.table-hover
   %tbody
     %tr

--- a/taskmanager_app/app/views/tasks/show.html.haml
+++ b/taskmanager_app/app/views/tasks/show.html.haml
@@ -1,7 +1,7 @@
 %h1 Tasks#show
 
 .nav.justify-content-end
-  = link_to(t('activerecord.terms.list'), tasks_path, class: 'nav-link')
+  = link_to(t('helpers.list'), tasks_path, class: 'nav-link')
 
 %table.table.table-hover
   %tbody

--- a/taskmanager_app/config/locales/ja.yml
+++ b/taskmanager_app/config/locales/ja.yml
@@ -7,6 +7,15 @@ ja:
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
+    models:
+      task: タスク
+    attributes:
+      task:
+        id: ID
+        name: 名称
+        description: 詳しい説明
+        created_at: 作成日時
+        updated_at: 更新日時
   date:
     abbr_day_names:
     - 日

--- a/taskmanager_app/config/locales/ja.yml
+++ b/taskmanager_app/config/locales/ja.yml
@@ -7,6 +7,8 @@ ja:
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
+    terms:
+      list: 一覧
     models:
       task: タスク
     attributes:

--- a/taskmanager_app/config/locales/ja.yml
+++ b/taskmanager_app/config/locales/ja.yml
@@ -7,8 +7,6 @@ ja:
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
-    terms:
-      list: 一覧
     models:
       task: タスク
     attributes:
@@ -156,6 +154,7 @@ ja:
       create: 登録する
       submit: 保存する
       update: 更新する
+    list: 一覧
   number:
     currency:
       format:


### PR DESCRIPTION
## 概要
ブラウザ上で表示されるモデルの情報を日本語に変換する


## 理由
モデルの属性名がそのまま表示されるよりは設計側で表示名を変更できるほうが自然な実装になると思ったため


## 確認方法
ビフォー：
![image](https://user-images.githubusercontent.com/49064351/60077930-f2a68080-9765-11e9-8830-3f54701daf6c.png)

アフター：
![image](https://user-images.githubusercontent.com/49064351/60077965-0356f680-9766-11e9-8a76-d65a7b478bf9.png)




## やっていないこと



## 相談事項

属性が増えるたびに翻訳情報も追記していくことになるのでその都度PR作成をするつもりです
