### PR TITLE
タイムゾーン設定のStyle修正

### DIFF
--- a/taskmanager_app/config/application.rb
+++ b/taskmanager_app/config/application.rb
@@ -11,7 +11,7 @@ module TaskmanagerApp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
-    config.time_zone = 'Tokyo'
+    config.time_zone = "Tokyo"
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
## 概要
シングルクォートで囲っていた文字列をダブルクォートに変更します。


## 理由
#6 で日本語設定を導入したのですが、この段階ではrubocopを実装していなかったので自動テストが行われずにマージしてしまいました。
その後、rubocopの文法エラーを発見したので修正したいです。



## 確認方法
![image](https://user-images.githubusercontent.com/49064351/60494568-031ca500-9cea-11e9-9031-3a6c71906f11.png)



## やっていないこと



## 相談事項
