### PR TITLE
Fix/step15 終了期限に関するテストコードの追加

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -18,9 +18,12 @@ class TasksController < ApplicationController
   end
 
   def update
-    task = Task.find(params[:id])
-    task.update!(task_params)
-    redirect_to(task_url, notice: t("helpers.edit.notice", name: task.name))
+    @task = Task.find(params[:id])
+    if @task.update(task_params)
+      redirect_to(task_url, notice: t("helpers.edit.notice", name: @task.name))
+    else
+      render :edit
+    end
   end
 
   def destroy

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -5,6 +5,6 @@ class Task < ApplicationRecord
   private
 
     def validate_deadline_minimum_value
-      errors.add(:deadline, "は現在時刻以降に設定してください") if !deadline.nil? && deadline < Time.zone.now
+      errors.add(:deadline, :after) if !deadline.nil? && deadline < Time.zone.now
     end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,3 +1,10 @@
 class Task < ApplicationRecord
   validates :name, presence: true, length: { maximum: 30 }
+  validate :validate_deadline_minimum_value
+
+  private
+
+    def validate_deadline_minimum_value
+      errors.add(:deadline, "は現在時刻以降に設定してください") if !deadline.nil? && deadline < Time.zone.now
+    end
 end

--- a/app/views/tasks/_form.html.haml
+++ b/app/views/tasks/_form.html.haml
@@ -12,6 +12,6 @@
     = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
   .form-group
     = f.label :deadline
-    - min_value = (task.created_at || Time.zone.now).strftime(t('date.formats.default'))
+    - min_value = Time.zone.now.strftime(t('date.formats.default'))
     = f.datetime_field :deadline, min: min_value, id: 'task_deadline', class: 'form-control'
   = f.submit nil, class: 'btn btn-primary'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,8 @@ ja:
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
+        deadline:
+          greater_than: "は現在時刻以降に設定してください"
     models:
       task: タスク
     attributes:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,8 +7,11 @@ ja:
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
-        deadline:
-          greater_than: "は現在時刻以降に設定してください"
+      models:
+        task:
+          attributes:
+            deadline:
+              after: は現在時刻以降に設定してください
     models:
       task: タスク
     attributes:

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -79,28 +79,71 @@ describe "タスク管理機能", type: :system do
   end
 
   describe "新規登録機能" do
-    let!(:attr_name) { Task.human_attribute_name(:name) }
+    describe "名称のバリデーション" do
+      let!(:attr_name) { Task.human_attribute_name(:name) }
 
-    before do
-      visit(new_task_path)
-      fill_in(attr_name, with: task_name)
-      click_button(I18n.t("helpers.submit.create"))
-    end
+      before do
+        visit(new_task_path)
+        fill_in(attr_name, with: task_name)
+        click_button(I18n.t("helpers.submit.create"))
+      end
 
-    context "名前を渡した場合" do
-      let(:task_name) { "適当な名前" }
+      context "名前を渡した場合" do
+        let(:task_name) { "適当な名前" }
 
-      it "新規登録できる" do
-        expect(page).to have_selector(".alert-success", text: "適当な名前")
+        it "新規登録できる" do
+          expect(page).to have_selector(".alert-success", text: "適当な名前")
+        end
+      end
+
+      context "名前を渡さなかった場合" do
+        let(:task_name) { "" }
+
+        it "エラーになる" do
+          within("#error_explanation") do
+            expect(page).to have_content("#{attr_name}を入力してください")
+          end
+        end
       end
     end
 
-    context "名前を渡さなかった場合" do
-      let(:task_name) { "" }
+    describe "終了期限のバリデーション" do
+      let!(:attr_name) { Task.human_attribute_name(:name) }
+      let!(:attr_deadline) { Task.human_attribute_name(:deadline) }
 
-      it "エラーになる" do
-        within("#error_explanation") do
-          expect(page).to have_content("#{attr_name}を入力してください")
+      before do
+        visit(new_task_path)
+        fill_in(attr_name, with: "適当な名称")
+        fill_in(attr_deadline, with: task_deadline)
+        click_button(I18n.t("helpers.submit.create"))
+      end
+
+      context "適切な終了期限を設定した場合" do
+        let(:task_deadline) { 1.day.from_now }
+
+        it "新規登録できる" do
+          expect(page).to have_selector(".alert-success", text: "適当な名称")
+        end
+      end
+
+      context "適切でない終了期限を設定した場合" do
+        # 何故か年の入力(西暦)は6桁まで受け付けるので、2桁足さないと月の数字が年に紛れ込む。
+        # 入力フォーム側で制限をかけるか迷ったが、fill_in自体の仕様な気がするので気がするので先頭に2桁足すことで誤魔化す。
+        # オプションで入力内容を調整できる可能性があるので、今後変更する可能性あり。
+        let(:task_deadline) { Time.zone.now.strftime("00%Y %m %d 00 00") }
+
+        it "新規登録できない" do
+          within("#error_explanation") do
+            expect(page).to have_content(I18n.t("activerecord.errors.messages.deadline.greater_than"))
+          end
+        end
+      end
+
+      context "終了期限を設定しなかった場合" do
+        let(:task_deadline) { nil }
+
+        it "新規登録できる" do
+          expect(page).to have_selector(".alert-success", text: "適当な名称")
         end
       end
     end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -131,7 +131,7 @@ describe "タスク管理機能", type: :system do
 
         it "新規登録できない" do
           within("#error_explanation") do
-            expect(page).to have_content(I18n.t("activerecord.errors.messages.deadline.greater_than"))
+            expect(page).to have_content("#{attr_deadline}は現在時刻以降に設定してください")
           end
         end
       end
@@ -201,7 +201,7 @@ describe "タスク管理機能", type: :system do
 
         it "新規登録できない" do
           within("#error_explanation") do
-            expect(page).to have_content(I18n.t("activerecord.errors.messages.deadline.greater_than"))
+            expect(page).to have_content("#{attr_deadline}は現在時刻以降に設定してください")
           end
         end
       end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -127,10 +127,7 @@ describe "タスク管理機能", type: :system do
       end
 
       context "適切でない終了期限を設定した場合" do
-        # 何故か年の入力(西暦)は6桁まで受け付けるので、2桁足さないと月の数字が年に紛れ込む。
-        # 入力フォーム側で制限をかけるか迷ったが、fill_in自体の仕様な気がするので気がするので先頭に2桁足すことで誤魔化す。
-        # オプションで入力内容を調整できる可能性があるので、今後変更する可能性あり。
-        let(:task_deadline) { Time.zone.now.strftime("00%Y %m %d 00 00") }
+        let(:task_deadline) { Time.zone.now.to_datetime }
 
         it "新規登録できない" do
           within("#error_explanation") do
@@ -200,10 +197,7 @@ describe "タスク管理機能", type: :system do
       end
 
       context "適切でない終了期限を設定した場合" do
-        # 何故か年の入力(西暦)は6桁まで受け付けるので、2桁足さないと月の数字が年に紛れ込む。
-        # 入力フォーム側で制限をかけるか迷ったが、fill_in自体の仕様な気がするので気がするので先頭に2桁足すことで誤魔化す。
-        # オプションで入力内容を調整できる可能性があるので、今後変更する可能性あり。
-        let(:task_deadline) { Time.zone.now.strftime("00%Y %m %d 00 00") }
+        let(:task_deadline) { Time.zone.now.to_datetime }
 
         it "新規登録できない" do
           within("#error_explanation") do


### PR DESCRIPTION
## 概要
終了期限に関するテストを追加。


## 理由
新規登録時・タスク編集時に適切な終了期限を入力した場合、適切でない終了期限を入力した場合の挙動を確認する必要があったため。


## 確認方法



## やっていないこと
`datetime` 形式の入力フィールドは、完全に空であるか完全に入力された状態以外では独自のエラーを返す。
(参考)
![image](https://user-images.githubusercontent.com/49064351/60782311-1f549200-a181-11e9-87bd-0e91636f55d0.png)
この時表示されるメッセージの取得は他のバリデーションエラーのメッセージとは別の手段を用意する必要がある。
実装のコストを考慮して今回はこのテストを実装しないいことにしました。


## 相談事項
