### PR TITLE
CI上でのマイグレーション・テスト失敗時のSS保存

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,6 @@ jobs:
           name: create Database
           command: |
             bundle exec rake db:create
-            bundle exec rake db:migrate
             bundle exec rake db:schema:load
 
       # run tests!

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,10 +56,15 @@ jobs:
 
       # collect reports
       - store_test_results:
+          path: tmp/screenshots/
+      - store_artifacts:
+          path: tmp/screenshots/
+          destination: test-results/screenshots/
+      - store_test_results:
           path: tmp/test-results/
       - store_artifacts:
           path: tmp/test-results/
-          destination: test-results
+          destination: test-results/
 
   rubocop:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ jobs:
           name: create Database
           command: |
             bundle exec rake db:create
+            bundle exec rake db:migrate
             bundle exec rake db:schema:load
 
       # run tests!


### PR DESCRIPTION
## 概要
- CI上でデータベース作成時にマイグレーション実行
- CI上でエラーが発生した場合のSS保存


## 理由
- CI上で作成されたdbでマイグレーションが適切に動作するか確認したかったため
- ローカル上では成功してCI上で失敗するテストがあった場合にSSの確認がしたいため。

## 確認方法
- CI上で`create Database` が正しく動作しているかどうか確認する
- テストが失敗した場合 `Artifacts` タブから確認できる
![image](https://user-images.githubusercontent.com/49064351/60792569-e3c9c000-a1a0-11e9-85f7-bb303ad3b364.png)



## やっていないこと



## 相談事項
