### PR TITLE
`Rails g` コマンドで生成されるテンプレートの設定を変更

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -17,5 +17,9 @@ module TaskmanagerApp
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+
+    config.generators do |g|
+      g.test_framework :rspec
+    end
   end
 end


### PR DESCRIPTION
## 概要
- ~~`Coffee` gemを無効化~~
- テストフレームワークの設定を`RSpec`に変更


## 理由
- ~~Coffeeは使用予定がないため~~
- 自動生成されるテストをRSpecように変更するのが煩わしかったため



## 確認方法
![image](https://user-images.githubusercontent.com/49064351/61110065-5ac4c880-a4c1-11e9-9611-c840ac7b2a51.png)




## やっていないこと



## 相談事項
jsファイルやscssも使用してないので、無効化できるならしたほうがいですかね？
jsは先のステップで使用する可能性はあるのですが、デフォルトで無効化して必要に応じてオプションで生成できるようにするでも十分だと思います。

gem自体を無効化するのではなく、生成のみを止める方向にする？