### PR TITLE
[WIP]FactoryBotの修正

### DIFF
--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -2,7 +2,7 @@ require "faker"
 
 FactoryBot.define do
   factory :task do
-    name { Faker::Name.name }
+    name { Faker::Alphanumeric.alphanumeric(1..30) }
     description { Faker::Lorem.paragraph }
     user
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,7 +2,7 @@ require "faker"
 
 FactoryBot.define do
   factory :user do
-    login_id { Faker::Internet.unique.username(4, []) }
+    login_id { Faker::Internet.unique.username(4..20, []) }
     password { Faker::Internet.password }
   end
 end

--- a/spec/models/tasks_spec.rb
+++ b/spec/models/tasks_spec.rb
@@ -4,6 +4,11 @@ describe Task, type: :model do
   describe "名前のバリデーション" do
     let(:task) { FactoryBot.create(:task) }
 
+    it "日本語名が使用できる" do
+      task.name = "日米kouryuu"
+      expect(task.valid?).to eq(true)
+    end
+
     context "30文字以上の場合に" do
       it "バリデーションエラーが発生する" do
         task.name = Faker::String.random(29)


### PR DESCRIPTION
## 概要
- Userの名前の長さに上限を設けた。
- Taskの名前の長さの範囲を設けた。

## 理由
modelに対してバリデーションを追加した時に、FactoryBotで生成される文字列に制限をかけていなかった。
そのため、検証結果がfalseになる文字列が生成されることがあった。
ランダム生成される文字列の長さを指定を追加することでこれを解消する。

String.randomだと特殊文字が原因でエラーが発生することがある。
Name.randomだと文字数の指定ができない
以上二点の理由から英数字を生成するAlphanumericを採用。
日本語名はテストでカバーするように変更

```
      def space_or_utf8_char(ratio)
        sample [32.chr(Encoding::UTF_8), [utf8character] * ratio].flatten
      end
```

https://github.com/stympy/faker/blob/3356fb09bd57b550906140b611e99911b76ec732/lib/faker/default/string.rb#L27-L29



## 確認方法
ローカルで


## やっていないこと



## 相談事項
